### PR TITLE
MiniGaffer: Added a CageVertexMask plug

### DIFF
--- a/include/Mini/MiniPointBind.h
+++ b/include/Mini/MiniPointBind.h
@@ -39,6 +39,8 @@ namespace MiniGaffer
             Gaffer::StringPlug *IndicesPrimVarPlug();
             const Gaffer::StringPlug *IndicesPrimVarPlug() const;
 
+            Gaffer::StringPlug *MaskPrimVarPlug();
+            const Gaffer::StringPlug *MaskPrimVarPlug() const;
 
             IE_CORE_DECLARERUNTIMETYPEDEXTENSION(MiniGaffer::MiniPointBind, MiniGaffer::TypeId::MiniPointBindTypeId, ObjectProcessor );
 


### PR DESCRIPTION
In should contain the name of an int vertex primvar. If this primvar is set to 1 for a given vertex then it's ignored from the binding.